### PR TITLE
Add --redirect-root flag to redirect the root URL to the served file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 - Markserv uses [Semantic Versioning](http://semver.org/)
 - Markserv [Keeps a ChangeLog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Added
+
+- `--redirect-root` flag: when launching Markserv with a file path, redirects the root URL `/` to the served file with an HTTP 302, instead of showing the parent directory index. Disabled by default; directory mode is unaffected.
+
 ## [1.19.1] - 2026-03-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -213,6 +213,18 @@ a {
 </style>
 ```
 
+## :twisted_rightwards_arrows: Redirect Root
+
+When Markserv is launched with a file path (not a directory), you can have the root URL `/` redirect straight to that file instead of showing the parent directory's index. This helps clients that can only reach `/` easily, such as mobile port-forwarders where typing a path is inconvenient.
+
+**Note:** Redirecting is disabled by default. Enable it with `--redirect-root`:
+
+```shell
+markserv --redirect-root README.md
+```
+
+With `--redirect-root` set, `GET /` responds with an HTTP 302 redirect to `/README.md`. Directory mode is unaffected — `/` still shows the directory index as usual.
+
 ## :crossed_flags: Flags
 
 To list the options/flags for the markserv CLI tool:

--- a/lib/cli-defs.js
+++ b/lib/cli-defs.js
@@ -43,6 +43,11 @@ module.exports = {
 		templates: {
 			type: 'boolean',
 			default: false
+		},
+
+		redirectRoot: {
+			type: 'boolean',
+			default: false
 		}
 	}
 }

--- a/lib/cli-help.txt
+++ b/lib/cli-help.txt
@@ -12,3 +12,4 @@ Options
 	--light  Use light theme (default: dark)
 	--synthwave  Use synthwave/retro-neon theme (default: dark)
 	--templates  Enable {file:}, {markdown:}, {html:}, {less:} templating (false)
+	--redirect-root  Redirect the root URL to the served file (false)

--- a/lib/server.js
+++ b/lib/server.js
@@ -320,6 +320,21 @@ const createRequestHandler = flags => {
 	}
 
 	flags.$openLocation = path.relative(dir, flags.dir)
+
+	// With --redirect-root, launching Markserv with a file path makes the
+	// root URL redirect to that file instead of showing the parent
+	// directory index, so clients that can only reach "/" (e.g. mobile
+	// port-forwarders that make paths hard to type) land on the intended
+	// document directly. Directory mode is unaffected.
+	// Use encodeURIComponent (not encodeURI): $openLocation is a single
+	// path segment (basename) in file mode, and encodeURI leaves "#"/"?"
+	// unescaped, which would make the browser misparse Location as a
+	// path plus fragment/query and break the redirect.
+	let rootFileRedirect = null
+	if (!isDir && flags.redirectRoot) {
+		rootFileRedirect = '/' + encodeURIComponent(flags.$openLocation)
+	}
+
 	const theme = resolveTheme(flags)
 	const themeFlags = {
 		themeDark: theme === 'dark',
@@ -415,6 +430,13 @@ const createRequestHandler = flags => {
 
 	return (req, res) => {
 		const decodedUrl = getPathFromUrl(decodeURIComponent(req.originalUrl))
+
+		if (decodedUrl === '/' && rootFileRedirect) {
+			res.writeHead(302, {location: rootFileRedirect})
+			res.end()
+			return
+		}
+
 		const filePath = path.normalize(unescape(dir) + unescape(decodedUrl))
 		const baseDir = path.parse(filePath).dir
 		implantOpts.baseDir = baseDir

--- a/tests/markserv-cli-redirect-root.test.js
+++ b/tests/markserv-cli-redirect-root.test.js
@@ -1,0 +1,149 @@
+import request from 'request'
+import test from 'ava'
+import getPort from 'get-port'
+import cli from '../lib/cli'
+
+test.cb('start markserv via "cli" command with --redirect-root opening a file: root URL redirects to the file', t => {
+	t.plan(3)
+
+	getPort().then(port => {
+		const cliOpts = {
+			input: ['README.md'],
+			flags: {
+				port,
+				hotreload: false,
+				address: 'localhost',
+				silent: true,
+				browser: false,
+				redirectRoot: true
+			}
+		}
+
+		const done = () => {
+			t.end()
+		}
+
+		cli.run(cliOpts).then(service => {
+			const closeServer = () => {
+				service.httpServer.close(done)
+			}
+
+			const opts = {
+				url: 'http://localhost:' + port + '/',
+				followRedirect: false,
+				timeout: 1000 * 2
+			}
+
+			request(opts, (err, res) => {
+				if (err) {
+					t.fail(err)
+					closeServer()
+					return
+				}
+
+				t.is(res.statusCode, 302)
+				t.is(res.headers.location, '/README.md')
+				t.pass()
+				closeServer()
+			})
+		}).catch(error => {
+			t.fail(error)
+			t.end()
+		})
+	})
+})
+
+test.cb('start markserv via "cli" command without --redirect-root opening a file: root URL still shows the directory index', t => {
+	t.plan(2)
+
+	getPort().then(port => {
+		const cliOpts = {
+			input: ['README.md'],
+			flags: {
+				port,
+				hotreload: false,
+				address: 'localhost',
+				silent: true,
+				browser: false
+			}
+		}
+
+		const done = () => {
+			t.end()
+		}
+
+		cli.run(cliOpts).then(service => {
+			const closeServer = () => {
+				service.httpServer.close(done)
+			}
+
+			const opts = {
+				url: 'http://localhost:' + port + '/',
+				timeout: 1000 * 2
+			}
+
+			request(opts, (err, res) => {
+				if (err) {
+					t.fail(err)
+					closeServer()
+					return
+				}
+
+				t.is(res.statusCode, 200)
+				t.pass()
+				closeServer()
+			})
+		}).catch(error => {
+			t.fail(error)
+			t.end()
+		})
+	})
+})
+
+test.cb('start markserv via "cli" command with --redirect-root opening a directory: root URL still shows the directory index', t => {
+	t.plan(2)
+
+	getPort().then(port => {
+		const cliOpts = {
+			input: ['tests'],
+			flags: {
+				port,
+				hotreload: false,
+				address: 'localhost',
+				silent: true,
+				browser: false,
+				redirectRoot: true
+			}
+		}
+
+		const done = () => {
+			t.end()
+		}
+
+		cli.run(cliOpts).then(service => {
+			const closeServer = () => {
+				service.httpServer.close(done)
+			}
+
+			const opts = {
+				url: 'http://localhost:' + port + '/',
+				timeout: 1000 * 2
+			}
+
+			request(opts, (err, res) => {
+				if (err) {
+					t.fail(err)
+					closeServer()
+					return
+				}
+
+				t.is(res.statusCode, 200)
+				t.pass()
+				closeServer()
+			})
+		}).catch(error => {
+			t.fail(error)
+			t.end()
+		})
+	})
+})


### PR DESCRIPTION
## What

Adds an opt-in boolean flag `--redirect-root` (default: `false`).

When Markserv is launched with a **file path** and this flag is set, `GET /` responds with an HTTP 302 redirect to that file instead of showing the parent directory index. Directory mode and all non-root paths are unaffected, and nothing changes unless the flag is explicitly passed.

```shell
markserv --redirect-root note.md
# GET /  ->  302 Location: /note.md
```

## Why

When serving a single Markdown file and accessing it from another device (e.g. a phone reaching the server through a port forwarder or a VPN such as Tailscale), the client often lands on `/` — and typing the file path on mobile is inconvenient. Today that shows the directory index of the file's parent, so reaching the intended document always costs an extra tap. With this flag, hitting the root URL lands directly on the document you asked Markserv to serve.

This is adjacent to (but distinct from) #68, which asks for a default file when browsing folders: this PR only affects file-mode launches and leaves directory browsing untouched.

## Implementation notes

- **302, not 301**: a permanent redirect would be cached by browsers and would keep pointing at a stale file if the same port later serves something else.
- The redirect target is `'/' + encodeURIComponent(basename)`. `encodeURIComponent` (rather than `encodeURI`) is used because file names containing `#` or `?` would otherwise produce a `Location` that browsers misparse as path + fragment/query.
- The `Location` value is computed once at startup from the CLI argument and never derives from request input, so it cannot be influenced by clients (no open-redirect / header-injection surface).

## Tests

- New `tests/markserv-cli-redirect-root.test.js` with three cases, following the style of `markserv-cli-file.test.js`:
  1. file + `--redirect-root` → `302` with `Location: /README.md`
  2. file without the flag → `200` (directory index, unchanged behavior)
  3. directory + `--redirect-root` → `200` (flag is a no-op in directory mode)
- Full `ava` suite: all tests pass except `error-page-404`, which also fails on current `master` in my environment (pre-existing, unrelated to this change).

## Notes for the maintainer

- `CHANGELOG.md` gets a new entry under an `[Unreleased]` heading — feel free to fold it into the next versioned heading, whichever matches your release flow.
- `README.md` gains a short "Redirect Root" section modeled on the Templating section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyejTLjhUCh7sEyHezN9Lg
